### PR TITLE
Transfer idyll-plugin-revision to idyll-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See each plugin for specific installation and usage instructions.
 
 * [Spellcheck](https://github.com/idyll-lang/idyll-plugin-spellcheck)
 * [Table of Contents](https://github.com/idyll-lang/idyll-plugin-table-of-contents)
-* [Git Revisions](https://github.com/ChristianFrisson/idyll-plugin-revision)
+* [Git Revisions](https://github.com/idyll-lang/idyll-plugin-revision)
 
 ### Runtime Plugins
 


### PR DESCRIPTION
Hey @mathisonian 
It makes more sense to have idyll-plugin-revision owned by idyll-lang, for sustainability, efficiency and visibility.
Kind regards,
Christian